### PR TITLE
fix: use expanded folder icons in batches

### DIFF
--- a/packages/icon-theme-worker/src/parts/GetIcon/GetIcon.ts
+++ b/packages/icon-theme-worker/src/parts/GetIcon/GetIcon.ts
@@ -114,7 +114,7 @@ export const getFolderIcon = (folder: any): string => {
   return getFolderNameIcon(folder.name)
 }
 
-const getFolderIconExpanded = (folder: any): string => {
+export const getFolderIconExpanded = (folder: any): string => {
   const baseUrl = IconThemeState.getExtensionBaseUrl()
 
   const iconTheme = IconThemeState.getIconTheme()

--- a/packages/icon-theme-worker/src/parts/GetIcons/GetIcons.ts
+++ b/packages/icon-theme-worker/src/parts/GetIcons/GetIcons.ts
@@ -1,9 +1,12 @@
-import { getFileIcon, getFolderIcon } from '../GetIcon/GetIcon.ts'
+import { getFileIcon, getFolderIcon, getFolderIconExpanded } from '../GetIcon/GetIcon.ts'
 
 export const getIcons = (iconRequests: readonly any[]): readonly string[] => {
   const Folder = 2
   const icons = iconRequests.map((request) => {
     if (request.type === Folder) {
+      if (request.expanded) {
+        return getFolderIconExpanded({ name: request.name })
+      }
       return getFolderIcon({ name: request.name })
     }
     return getFileIcon({ name: request.name })

--- a/packages/icon-theme-worker/test/GetIcon.test.ts
+++ b/packages/icon-theme-worker/test/GetIcon.test.ts
@@ -3,6 +3,7 @@ import type { Dirent } from '../src/parts/Dirent/Dirent.ts'
 import * as DefaultIcon from '../src/parts/DefaultIcon/DefaultIcon.ts'
 import * as GetIcon from '../src/parts/GetIcon/GetIcon.ts'
 import { getIcons } from '../src/parts/GetIcons/GetIcons.ts'
+import * as IconThemeState from '../src/parts/IconThemeState/IconThemeState.ts'
 
 beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {})
@@ -96,6 +97,36 @@ test('getIcons should handle mixed file and folder requests', () => {
   expect(result).toHaveLength(2)
   expect(typeof result[0]).toBe('string')
   expect(typeof result[1]).toBe('string')
+})
+
+test('getIcons should use expanded folder icon for expanded folder requests', () => {
+  IconThemeState.setTheme({
+    extensionBaseUrl: '/remote',
+    extensionPath: '',
+    extensionRemoteUri: '',
+    extensionUri: '',
+    json: {
+      folderNames: {
+        packages: 'folder-packages',
+      },
+      folderNamesExpanded: {
+        packages: 'folder-packages-open',
+      },
+      iconDefinitions: {
+        _folder: '/folder.svg',
+        _folder_open: '/folder-open.svg',
+        'folder-packages': '/folder-packages.svg',
+        'folder-packages-open': '/folder-packages-open.svg',
+      },
+    },
+  })
+
+  const result = getIcons([
+    { name: 'packages', type: 2 },
+    { expanded: true, name: 'packages', type: 2 },
+  ])
+
+  expect(result).toEqual(['/remote/folder-packages.svg', '/remote/folder-packages-open.svg'])
 })
 
 test('getFileNameIcon should handle empty filename', () => {


### PR DESCRIPTION
Routes batched expanded folder icon requests through the expanded folder icon resolver so folderNamesExpanded and folder_open icons can be used.