### PR TITLE
feature: optimize builtin file icon urls

### DIFF
--- a/packages/icon-theme-worker/src/parts/DoGetIconThemeJson/DoGetIconThemeJson.ts
+++ b/packages/icon-theme-worker/src/parts/DoGetIconThemeJson/DoGetIconThemeJson.ts
@@ -4,6 +4,7 @@ import * as FindMatchingIconThemeExtension from '../FindMatchingIconThemeExtensi
 import { getIconThemeJsonUrl } from '../GetIconThemeJsonUrl/GetIconThemeJsonUrl.ts'
 import * as GetIconThemeUrl from '../GetIconThemeUrl/GetIconThemeUrl.ts'
 import { getJsonCached } from '../GetJsonCached/GetJsonCached.ts'
+import { optimizeBuiltinIconTheme } from '../OptimizeBuiltinIconTheme/OptimizeBuiltinIconTheme.ts'
 
 export const doGetIconThemeJson = async (
   extensions: readonly any[],
@@ -33,6 +34,15 @@ export const doGetIconThemeJson = async (
   }
   const iconThemeUrl = getIconThemeJsonUrl(iconTheme)
   const iconThemeJson = await getJsonCached(iconThemeUrl, useCache, bucketName, cacheName, locationProtocol, iconThemeId, commit)
+  if (platform === PlatformType.Electron && iconTheme.extensionId === 'builtin.vscode-icons') {
+    return {
+      extensionBaseUrl: assetDir,
+      extensionPath: iconTheme.extensionPath,
+      extensionRemoteUri: '',
+      extensionUri: iconTheme.extensionUri || '',
+      json: optimizeBuiltinIconTheme(iconThemeJson, iconTheme.extensionId),
+    }
+  }
   return {
     extensionBaseUrl: iconTheme.extensionRemoteUri || '',
     extensionPath: iconTheme.extensionPath,

--- a/packages/icon-theme-worker/src/parts/FindMatchingIconThemeExtension/FindMatchingIconThemeExtension.ts
+++ b/packages/icon-theme-worker/src/parts/FindMatchingIconThemeExtension/FindMatchingIconThemeExtension.ts
@@ -9,6 +9,7 @@ export const findMatchingIconThemeExtension = (extensions: readonly any[], iconT
           const extensionRemoteUri = getExtensionRemoteUri(extension.uri, extension.path, platform)
           return {
             ...iconTheme,
+            extensionId: extension.id,
             extensionPath: extension.path,
             extensionRemoteUri,
             extensionUri: extension.uri,

--- a/packages/icon-theme-worker/src/parts/OptimizeBuiltinIconTheme/OptimizeBuiltinIconTheme.ts
+++ b/packages/icon-theme-worker/src/parts/OptimizeBuiltinIconTheme/OptimizeBuiltinIconTheme.ts
@@ -1,0 +1,27 @@
+const vscodeIconsExtensionId = 'builtin.vscode-icons'
+const vscodeIconsPathPrefix = '/icons/'
+const optimizedPathPrefix = '/file-icons/'
+
+interface IconTheme {
+  readonly iconDefinitions?: Readonly<Record<string, unknown>>
+  readonly [key: string]: unknown
+}
+
+const optimizeIconPath = (iconPath: unknown): unknown => {
+  if (typeof iconPath !== 'string' || !iconPath.startsWith(vscodeIconsPathPrefix)) {
+    return iconPath
+  }
+  return `${optimizedPathPrefix}${iconPath.slice(vscodeIconsPathPrefix.length)}`
+}
+
+export const optimizeBuiltinIconTheme = (iconTheme: IconTheme, extensionId: string): IconTheme => {
+  if (extensionId !== vscodeIconsExtensionId || !iconTheme?.iconDefinitions) {
+    return iconTheme
+  }
+  return {
+    ...iconTheme,
+    iconDefinitions: Object.fromEntries(
+      Object.entries(iconTheme.iconDefinitions).map((entry: readonly [string, unknown]) => [entry[0], optimizeIconPath(entry[1])]),
+    ),
+  }
+}

--- a/packages/icon-theme-worker/test/DoGetIconThemeJson.test.ts
+++ b/packages/icon-theme-worker/test/DoGetIconThemeJson.test.ts
@@ -48,3 +48,44 @@ test('doGetIconThemeJson should return undefined when icon theme is not found fo
 
   expect(result).toBeUndefined()
 })
+
+test('doGetIconThemeJson should use optimized paths for builtin vscode-icons on electron', async () => {
+  const mockJson = {
+    iconDefinitions: {
+      _file: '/icons/default_file.svg',
+    },
+  }
+  globalThis.fetch = async (): Promise<Response> => {
+    return {
+      json: async () => mockJson,
+      ok: true,
+    } as unknown as Response
+  }
+  const extensions = [
+    {
+      iconThemes: [
+        {
+          id: 'vscode-icons',
+          path: 'icon-theme.json',
+        },
+      ],
+      id: 'builtin.vscode-icons',
+      path: '/usr/lib/lvce/resources/app/static/abc/extensions/builtin.vscode-icons',
+      uri: 'file:///usr/lib/lvce/resources/app/static/abc/extensions/builtin.vscode-icons',
+    },
+  ]
+
+  const result = await DoGetIconThemeJson.doGetIconThemeJson(extensions, 'vscode-icons', '/abc', PlatformType.Electron, false, 'abc')
+
+  expect(result).toEqual({
+    extensionBaseUrl: '/abc',
+    extensionPath: '/usr/lib/lvce/resources/app/static/abc/extensions/builtin.vscode-icons',
+    extensionRemoteUri: '',
+    extensionUri: 'file:///usr/lib/lvce/resources/app/static/abc/extensions/builtin.vscode-icons',
+    json: {
+      iconDefinitions: {
+        _file: '/file-icons/default_file.svg',
+      },
+    },
+  })
+})

--- a/packages/icon-theme-worker/test/OptimizeBuiltinIconTheme.test.ts
+++ b/packages/icon-theme-worker/test/OptimizeBuiltinIconTheme.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@jest/globals'
+import { optimizeBuiltinIconTheme } from '../src/parts/OptimizeBuiltinIconTheme/OptimizeBuiltinIconTheme.ts'
+
+test('optimizes vscode-icons paths', () => {
+  const iconTheme = {
+    iconDefinitions: {
+      _file: '/icons/default_file.svg',
+      _file_light: '',
+    },
+  }
+
+  expect(optimizeBuiltinIconTheme(iconTheme, 'builtin.vscode-icons')).toEqual({
+    iconDefinitions: {
+      _file: '/file-icons/default_file.svg',
+      _file_light: '',
+    },
+  })
+})
+
+test('does not optimize another extension', () => {
+  const iconTheme = {
+    iconDefinitions: {
+      _file: '/icons/default_file.svg',
+    },
+  }
+
+  expect(optimizeBuiltinIconTheme(iconTheme, 'sample.vscode-icons')).toBe(iconTheme)
+})


### PR DESCRIPTION
## Summary

Use the commit-scoped asset directory for Electron's built-in vscode-icons theme and rewrite its icon definitions to /file-icons paths. Other icon theme extensions keep their existing URL handling.