### PR TITLE
fix: reuse cached icon themes by content etag

### DIFF
--- a/packages/icon-theme-worker/src/parts/DoGetIconThemeJson/DoGetIconThemeJson.ts
+++ b/packages/icon-theme-worker/src/parts/DoGetIconThemeJson/DoGetIconThemeJson.ts
@@ -12,14 +12,14 @@ export const doGetIconThemeJson = async (
   assetDir: string,
   platform: number,
   useCache: boolean,
-  commit: string,
+  etag: string,
 ): Promise<LoadedIconTheme | undefined> => {
   const cacheName = 'lvce-editor-icon-themes'
   const bucketName = 'lvce-editor-icon-themes'
   const locationProtocol = location.protocol
   if (platform === PlatformType.Web) {
     const url = GetIconThemeUrl.getIconThemeUrl(assetDir, iconThemeId)
-    const json = await getJsonCached(url, useCache, bucketName, cacheName, locationProtocol, iconThemeId, commit)
+    const json = await getJsonCached(url, useCache, bucketName, cacheName, locationProtocol, iconThemeId, etag)
     return {
       extensionBaseUrl: `${assetDir}/extensions/builtin.${iconThemeId}`,
       extensionPath: `${assetDir}/extensions/builtin.${iconThemeId}`,
@@ -33,7 +33,7 @@ export const doGetIconThemeJson = async (
     return undefined
   }
   const iconThemeUrl = getIconThemeJsonUrl(iconTheme)
-  const iconThemeJson = await getJsonCached(iconThemeUrl, useCache, bucketName, cacheName, locationProtocol, iconThemeId, commit)
+  const iconThemeJson = await getJsonCached(iconThemeUrl, useCache, bucketName, cacheName, locationProtocol, iconThemeId, etag)
   if (platform === PlatformType.Electron && iconTheme.extensionId === 'builtin.vscode-icons') {
     return {
       extensionBaseUrl: assetDir,

--- a/packages/icon-theme-worker/src/parts/GetIconThemeCacheKey/GetIconThemeCacheKey.ts
+++ b/packages/icon-theme-worker/src/parts/GetIconThemeCacheKey/GetIconThemeCacheKey.ts
@@ -23,8 +23,8 @@ const getPrefix = (locationProtocol: string): string => {
   return `https://-`
 }
 
-export const getIconThemeCacheKey = async (etag: string, iconThemeId: string, commit: string, locationProtocol: string): Promise<string> => {
+export const getIconThemeCacheKey = async (etag: string, iconThemeId: string, locationProtocol: string): Promise<string> => {
   const hash = getCacheHash(etag)
   const prefix = getPrefix(locationProtocol)
-  return `${prefix}/icon-themes/${iconThemeId}/${commit}/${hash}`
+  return `${prefix}/icon-themes/${iconThemeId}/${hash}`
 }

--- a/packages/icon-theme-worker/src/parts/GetIconThemeJson/GetIconThemeJson.ts
+++ b/packages/icon-theme-worker/src/parts/GetIconThemeJson/GetIconThemeJson.ts
@@ -2,7 +2,7 @@ import { doGetIconThemeJson } from '../DoGetIconThemeJson/DoGetIconThemeJson.ts'
 import * as IconThemeState from '../IconThemeState/IconThemeState.ts'
 
 // TODO use cache storage or indexeddb for caching color theme
-// use unique cache key based on content hash and/or commit hash
+// use unique cache key based on content hash
 // when it's not cached, fetch should be quite fast
 // though one needs to take care to not allow this worker or any worker
 // read arbitrary files on disk
@@ -16,12 +16,12 @@ export const loadIconThemeJson = async (
   assetDir: string,
   platform: number,
   useCache: boolean,
-  commit: string,
+  etag = '',
 ): Promise<any> => {
   if (!iconThemeId) {
     return ''
   }
-  const json = await doGetIconThemeJson(extensions, iconThemeId, assetDir, platform, useCache, commit)
+  const json = await doGetIconThemeJson(extensions, iconThemeId, assetDir, platform, useCache, etag)
   IconThemeState.setTheme(json)
   return json
 }

--- a/packages/icon-theme-worker/src/parts/GetJsonCached/GetJsonCached.ts
+++ b/packages/icon-theme-worker/src/parts/GetJsonCached/GetJsonCached.ts
@@ -10,25 +10,28 @@ export const getJsonCached = async (
   cacheName: string,
   locationProtocol: string,
   iconThemeId = '-',
-  commit = '-',
+  etag = '',
 ): Promise<any> => {
   if (!useCache) {
     return getJson(url)
   }
 
   try {
-    const headResponse = await fetch(url, { method: 'HEAD' })
-    if (!headResponse.ok) {
-      throw new Error(headResponse.statusText)
-    }
+    let resolvedEtag = etag
+    if (!resolvedEtag) {
+      const headResponse = await fetch(url, { method: 'HEAD' })
+      if (!headResponse.ok) {
+        throw new Error(headResponse.statusText)
+      }
 
-    const etag = headResponse.headers.get('etag')
-    if (!etag) {
-      return getJson(url)
+      resolvedEtag = headResponse.headers.get('etag') || ''
+      if (!resolvedEtag) {
+        return getJson(url)
+      }
     }
 
     const cache = await getCache(bucketName, cacheName)
-    const cacheKey = await getIconThemeCacheKey(etag, iconThemeId, commit, locationProtocol)
+    const cacheKey = await getIconThemeCacheKey(resolvedEtag, iconThemeId, locationProtocol)
     const cachedResponse = await cache.match(cacheKey)
 
     if (cachedResponse) {

--- a/packages/icon-theme-worker/test/GetJsonCached.test.ts
+++ b/packages/icon-theme-worker/test/GetJsonCached.test.ts
@@ -210,6 +210,53 @@ test('getJsonCached should use cache when useCache is true', async () => {
   expect(getCallCount).toBe(1)
 })
 
+test('getJsonCached should reuse a provided content etag across deployment URLs without a HEAD request', async () => {
+  const mockData = { name: 'test', value: 123 }
+  const mockCache = createMockCache()
+  setupMockStorageBuckets(mockCache)
+  let getCallCount = 0
+  let headCallCount = 0
+
+  mockFetch({
+    getResponse: () => {
+      getCallCount++
+      return Response.json(mockData)
+    },
+    onCall: (_url: string, method?: string) => {
+      if (method === 'HEAD') {
+        headCallCount++
+      }
+      return undefined
+    },
+  })
+
+  const cacheName = `test-cache-${Date.now()}-${Math.random()}`
+  const etag = 'content-hash'
+  const result1 = await GetJsonCached.getJsonCached(
+    'https://example.com/first-deployment/icon-theme.json',
+    true,
+    'test-bucket',
+    cacheName,
+    'https:',
+    'test-theme',
+    etag,
+  )
+  const result2 = await GetJsonCached.getJsonCached(
+    'https://example.com/second-deployment/icon-theme.json',
+    true,
+    'test-bucket',
+    cacheName,
+    'https:',
+    'test-theme',
+    etag,
+  )
+
+  expect(result1).toEqual(mockData)
+  expect(result2).toEqual(mockData)
+  expect(getCallCount).toBe(1)
+  expect(headCallCount).toBe(0)
+})
+
 test('getJsonCached should throw VError when fetch fails and useCache is false', async () => {
   mockFetch({
     getResponse: () => {


### PR DESCRIPTION
Use a build-provided icon theme content ETag when available and fall back to the runtime HEAD request otherwise. Cache keys no longer include deployment-specific commit data, so identical icon themes are reused across releases.